### PR TITLE
Temporarily set pulumi version on mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 "vfox-pulumi:pulumi/pulumi-std" = "latest"
 "vfox-pulumi:pulumi/pulumi-converter-terraform" = "latest"
+pulumi = '3.213'


### PR DESCRIPTION
Part of #565 

* The mise version detection is currently broken (it's defaulting to `pulumi@latest`).
* `pulumi@latest` points to `pulumi@3.217`.
* The Terraform Bridge version requires `pulumi@3.213` so I cannot update this module to use `pulumi@3.217` (see below)
* Temporarily override to `mise` to unblock builds and workflow failures.

---

## Errors while trying build after upgrade to `3.217`

```
# github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen
../../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.119.0/pkg/tfgen/pluginHost.go:33:27: cannot convert (*inmemoryProvider)(nil) (value of type *inmemoryProvider) to type plugin.Provider: *inmemoryProvider does not implement plugin.Provider (wrong type for method GetPluginInfo)
		have GetPluginInfo("context".Context) ("github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PluginInfo, error)
		want GetPluginInfo("context".Context) (plugin.PluginInfo, error)
../../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.119.0/pkg/tfgen/pluginHost.go:124:10: cannot use host.provider (variable of type *inmemoryProvider) as plugin.Provider value in return statement: *inmemoryProvider does not implement plugin.Provider (wrong type for method GetPluginInfo)
		have GetPluginInfo("context".Context) ("github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PluginInfo, error)
		want GetPluginInfo("context".Context) (plugin.PluginInfo, error)
../../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.119.0/pkg/tfgen/pluginHost.go:126:28: cannot use pkg (variable of struct type "github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PackageDescriptor) as "github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PluginDescriptor value in argument to host.Host.Provider
../../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.119.0/pkg/tfgen/pluginHost.go:161:9: cannot use &cachingProviderHost{…} (value of type *cachingProviderHost) as plugin.Host value in return statement: *cachingProviderHost does not implement plugin.Host (wrong type for method Provider)
		have Provider("github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PackageDescriptor) (plugin.Provider, error)
		want Provider("github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PluginDescriptor) (plugin.Provider, error)
../../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.119.0/pkg/tfgen/pluginHost.go:184:38: cannot use pkg (variable of struct type "github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PackageDescriptor) as "github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PluginDescriptor value in argument to host.Host.Provider
../../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.119.0/pkg/tfgen/generate.go:1013:43: cannot use host (variable of type *inmemoryProviderHost) as plugin.Host value in argument to newCachingProviderHost: *inmemoryProviderHost does not implement plugin.Host (wrong type for method Provider)
		have Provider("github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PackageDescriptor) (plugin.Provider, error)
		want Provider("github.com/pulumi/pulumi/sdk/v3/go/common/workspace".PluginDescriptor) (plugin.Provider, error)
```