### PR TITLE
Revert "Temporarily set pulumi version on mise.toml"

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,3 @@
 [tools]
 "vfox-pulumi:pulumi/pulumi-std" = "latest"
 "vfox-pulumi:pulumi/pulumi-converter-terraform" = "latest"
-pulumi = '3.213'


### PR DESCRIPTION
Reverts pulumi/pulumi-harness#572

Fixes https://github.com/pulumi/home/issues/4496

No longer required as https://github.com/pulumi/pulumi/pull/21603 has been fixed (root cause of the breakage)

Related to: https://github.com/pulumi/home/issues/4495